### PR TITLE
Dependency annotations (ES7)

### DIFF
--- a/package.js
+++ b/package.js
@@ -35,6 +35,7 @@ Package.onUse(function(api) {
     'source/object.coffee',
     'source/struct.coffee',
     'source/injector.coffee',
+    'source/injector_annotations.coffee',
     'source/module.coffee',
     'source/application.coffee'
   ]);
@@ -55,6 +56,7 @@ Package.onTest(function(api) {
     'session',
     'reactive-var',
 
+    'grigio:babel@0.1.3',
     'practicalmeteor:munit@2.0.2',
     'space:testing@1.3.0',
   ]);
@@ -67,6 +69,7 @@ Package.onTest(function(api) {
     'tests/unit/struct.unit.coffee',
     'tests/unit/application.unit.coffee',
     'tests/unit/injector.unit.coffee',
+    'tests/unit/injector_annotations.unit.es6',
     'tests/unit/helpers.unit.coffee',
 
     // integration tests

--- a/source/injector_annotations.coffee
+++ b/source/injector_annotations.coffee
@@ -1,10 +1,10 @@
-@Dependency = (propertyName, dependencyId) ->
+@Space.Dependency = (propertyName, dependencyId) ->
   (target) ->
     target.prototype.Dependencies ?= {}
     target.prototype.Dependencies[propertyName] = dependencyId
     return target
 
-@RequireModule = (moduleId) ->
+@Space.RequireModule = (moduleId) ->
   (target) ->
     target.prototype.RequiredModules ?= []
     target.prototype.RequiredModules.push moduleId

--- a/source/injector_annotations.coffee
+++ b/source/injector_annotations.coffee
@@ -1,0 +1,11 @@
+@Dependency = (propertyName, dependencyId) ->
+  (target) ->
+    target.prototype.Dependencies ?= {}
+    target.prototype.Dependencies[propertyName] = dependencyId
+    return target
+
+@RequireModule = (moduleId) ->
+  (target) ->
+    target.prototype.RequiredModules ?= []
+    target.prototype.RequiredModules.push moduleId
+    return target

--- a/tests/unit/injector_annotations.unit.es6
+++ b/tests/unit/injector_annotations.unit.es6
@@ -1,0 +1,32 @@
+describe('Space.Injector annotations', function () {
+
+  describe('Dependency annotation', function () {
+
+    it('adds the dependency to the Dependencies map', function () {
+      @Dependency('propertyName1', 'dependencyName1')
+      @Dependency('propertyName2', 'dependencyName2')
+      class FixtureClass {}
+
+      expect(FixtureClass.prototype.Dependencies).to.deep.equal({
+        'propertyName1': 'dependencyName1',
+        'propertyName2': 'dependencyName2'
+      });
+    });
+
+  })
+
+  describe('RequireModule annotation', function () {
+
+    it('adds the required module to the RequiredModules array', function () {
+      @RequireModule('fooModule1')
+      @RequireModule('fooModule2')
+      class FixtureClass {}
+
+      expect(FixtureClass.prototype.RequiredModules).to.contain('fooModule1');
+      expect(FixtureClass.prototype.RequiredModules).to.contain('fooModule2');
+    });
+
+  });
+
+});
+

--- a/tests/unit/injector_annotations.unit.es6
+++ b/tests/unit/injector_annotations.unit.es6
@@ -3,8 +3,8 @@ describe('Space.Injector annotations', function () {
   describe('Dependency annotation', function () {
 
     it('adds the dependency to the Dependencies map', function () {
-      @Dependency('propertyName1', 'dependencyName1')
-      @Dependency('propertyName2', 'dependencyName2')
+      @Space.Dependency('propertyName1', 'dependencyName1')
+      @Space.Dependency('propertyName2', 'dependencyName2')
       class FixtureClass {}
 
       expect(FixtureClass.prototype.Dependencies).to.deep.equal({
@@ -18,8 +18,8 @@ describe('Space.Injector annotations', function () {
   describe('RequireModule annotation', function () {
 
     it('adds the required module to the RequiredModules array', function () {
-      @RequireModule('fooModule1')
-      @RequireModule('fooModule2')
+      @Space.RequireModule('fooModule1')
+      @Space.RequireModule('fooModule2')
       class FixtureClass {}
 
       expect(FixtureClass.prototype.RequiredModules).to.contain('fooModule1');


### PR DESCRIPTION
I've started to use ES6 with grigio:babel. ES6 classes don't allow you to add properties. So the only way would be to add this properties after the class declaration. I think it's better when the dependencies are annotated on the top.

This pull request adds the capability to declare your dependencies with the ES7 annotations that are also available with Babel. It's inspired by https://github.com/angular/di.js/.

You can see an example in the tests.